### PR TITLE
Fixes double rendering of products, fixes duplicate placeholder arg

### DIFF
--- a/views/spree/shared/_products.html.erb
+++ b/views/spree/shared/_products.html.erb
@@ -18,7 +18,6 @@
 
 <% if products.any? %>
   <div id="products" class="product-list" data-hook>
-    <%= render partial: 'spree/products/product', collection: products, locals: { taxon: @taxon } %>
     <% products.each do |product| %>
       <% url = spree.product_path(product, taxon_id: @taxon.try(:id)) %>
       <div id="product_<%= product.id %>" data-hook="products_list_item" class="product-list-item" itemscope itemtype="https://schema.org/Product">

--- a/views/spree/shared/_search.html.erb
+++ b/views/spree/shared/_search.html.erb
@@ -10,7 +10,7 @@
                                     @taxon ? @taxon.id : params[:taxon]), 'aria-label' => 'Taxon', class: "form-control" %>
       <%# end %>
     <!-- </div> -->
-    <%= search_field_tag :keywords, params[:keywords], placeholder: Spree.t(:search), class: "", placeholder: "SEARCH HERE..." %>
+    <%= search_field_tag :keywords, params[:keywords], placeholder: Spree.t(:search) %>
     <%= button_tag '', name: nil, class: "fa fa-search search-btn" %>
   <% end %>
 </div>


### PR DESCRIPTION
Fixes:

- double rendering of products in partial
- fixes warning: `/vinsol_spree_themes/current/views/spree/shared/_search.html.erb:13: warning: key :placeholder is duplicated and overwritten on line 13`